### PR TITLE
Created ARCHITECHTURE.md file in English, Korean and Japanese along with linking in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,6 +80,8 @@ updoc/
 └── Makefile             # Build automation
 ```
 
+For detailed architecture information, component interactions, and design decisions, see the [Architecture Documentation](docs/ARCHITECTURE.md).
+
 ## How to Contribute
 
 ### Reporting Bugs
@@ -289,6 +291,7 @@ func TestParseRequest_Validate(t *testing.T) {
 |------|---------|
 | `README.md` | Project overview and quick start |
 | `docs/CLI_MANUAL.md` | Detailed CLI reference |
+| `docs/ARCHITECTURE.md` | Architecture and design documentation |
 | `CONTRIBUTING.md` | Contribution guidelines |
 
 ### Multilingual Support

--- a/README.md
+++ b/README.md
@@ -271,6 +271,8 @@ updoc/
 └── Makefile
 ```
 
+For detailed architecture information, see the [Architecture Documentation](docs/ARCHITECTURE.md).
+
 ## License
 
 MIT License
@@ -278,6 +280,7 @@ MIT License
 ## References
 
 - [CLI Manual](docs/CLI_MANUAL.md)
+- [Architecture Documentation](docs/ARCHITECTURE.md)
 - [Upstage Document Parse Documentation](https://console.upstage.ai/docs/capabilities/document-parse)
 - [Upstage API Reference](https://console.upstage.ai/api-reference)
 - [Upstage Console](https://console.upstage.ai)

--- a/docs/ARCHITECTURE.ja.md
+++ b/docs/ARCHITECTURE.ja.md
@@ -1,0 +1,545 @@
+# アーキテクチャドキュメント
+
+[English](ARCHITECTURE.md) | [한국어](ARCHITECTURE.ko.md)
+
+このドキュメントは、`updoc` CLIツールの全体的なアーキテクチャ、設計決定、コンポーネント間の相互作用を説明します。
+
+## 目次
+
+- [システム概要](#システム概要)
+- [パッケージ構造](#パッケージ構造)
+- [データフロー](#データフロー)
+- [設定階層](#設定階層)
+- [エラーハンドリング戦略](#エラーハンドリング戦略)
+- [拡張ポイント](#拡張ポイント)
+
+## システム概要
+
+`updoc`は、Upstage Document Parse APIのコマンドラインインターフェースです。同期および非同期のAPI呼び出しを通じて、ドキュメント（PDF、Officeファイル、画像）を構造化されたテキスト形式（HTML、Markdown、Text）に変換する簡単な方法を提供します。
+
+### 高レベルアーキテクチャ
+
+```mermaid
+graph TB
+    User[ユーザー] --> CLI[CLIコマンド]
+    CLI --> Config[設定マネージャー]
+    CLI --> API[APIクライアント]
+    API --> HTTP[HTTPクライアント]
+    HTTP --> UpstageAPI[Upstage API]
+    UpstageAPI --> HTTP
+    HTTP --> API
+    API --> Response[パース応答]
+    Response --> Formatter[出力フォーマッター]
+    Formatter --> Output[フォーマット済み出力]
+    Output --> User
+    
+    Config --> EnvVars[環境変数]
+    Config --> ConfigFile[設定ファイル]
+    Config --> CLI
+```
+
+### コンポーネントの責任
+
+| コンポーネント | 責任 |
+|---------------|------|
+| **CLIコマンド** (`internal/cmd`) | ユーザー入力のパース、引数の検証、ワークフローの調整 |
+| **APIクライアント** (`internal/api`) | Upstage APIとのHTTP通信の処理、リクエスト/レスポンスのライフサイクル管理 |
+| **設定マネージャー** (`internal/config`) | 複数のソース（環境変数、設定ファイル、CLIフラグ）から設定をロードおよびマージ |
+| **出力フォーマッター** (`internal/output`) | APIレスポンスをユーザー要求形式（HTML、Markdown、Text、JSON）に変換 |
+| **エントリーポイント** (`cmd/updoc`) | CLIフレームワークの初期化とアプリケーションのライフサイクル処理 |
+
+## パッケージ構造
+
+```
+updoc/
+├── cmd/updoc/              # アプリケーションエントリーポイント
+│   └── main.go            # CLIの初期化とエラー処理
+│
+├── internal/
+│   ├── api/               # Upstage APIクライアント
+│   │   ├── client.go      # HTTPクライアントの実装
+│   │   └── types.go       # APIリクエスト/レスポンスタイプ
+│   │
+│   ├── cmd/               # CLIコマンドの実装
+│   │   ├── root.go        # ルートコマンドと共有ユーティリティ
+│   │   ├── parse.go       # パースコマンド（同期/非同期）
+│   │   ├── status.go      # ステータス確認コマンド
+│   │   ├── result.go      # 結果取得コマンド
+│   │   ├── config.go      # 設定管理コマンド
+│   │   ├── models.go      # モデル一覧コマンド
+│   │   └── version.go     # バージョンコマンド
+│   │
+│   ├── config/            # 設定管理
+│   │   └── config.go      # 設定のロード、保存、検証
+│   │
+│   └── output/            # 出力フォーマット
+│       └── formatter.go   # フォーマットコンバーター（HTML、Markdown、Text、JSON）
+│
+├── test/                  # テストファイル
+│   ├── e2e/              # エンドツーエンドテスト
+│   └── testdata/         # テストフィクスチャ
+│
+└── docs/                  # ドキュメント
+    ├── ARCHITECTURE.md   # このファイル
+    └── CLI_MANUAL.md     # CLIリファレンス
+```
+
+### パッケージの詳細
+
+#### `cmd/updoc`
+- **目的**: アプリケーションエントリーポイント
+- **責任**: Cobra CLIフレームワークの初期化、トップレベルのエラー処理
+- **依存関係**: `internal/cmd`
+
+#### `internal/api`
+- **目的**: Upstage APIクライアントの抽象化
+- **責任**:
+  - HTTPリクエストの構築（ファイルアップロード用のマルチパートフォームデータ）
+  - API認証の処理（Bearerトークン）
+  - APIレスポンスとエラーのパース
+  - 同期および非同期操作のサポート
+- **主要タイプ**: `Client`, `ParseRequest`, `ParseResponse`, `AsyncResponse`, `StatusResponse`
+
+#### `internal/cmd`
+- **目的**: CLIコマンドの実装
+- **責任**:
+  - コマンド構造とフラグの定義
+  - ユーザー入力の検証
+  - APIクライアント、設定、出力フォーマッター間の調整
+  - バッチ処理の処理
+  - 非同期ワークフローの管理（パース → ステータス → 結果）
+- **主要コマンド**: `parse`, `status`, `result`, `config`, `models`, `version`
+
+#### `internal/config`
+- **目的**: 設定管理
+- **責任**:
+  - YAMLファイルから設定をロード
+  - 環境変数から設定をマージ
+  - 設定階層の解決を提供
+  - 設定値の検証
+  - 設定ファイルへの保存
+- **主要タイプ**: `Config`
+
+#### `internal/output`
+- **目的**: 出力フォーマット
+- **責任**:
+  - APIレスポンスを要求された形式に変換
+  - 複数の出力形式をサポート（HTML、Markdown、Text、JSON）
+  - 要素のみの出力モードの処理
+- **主要タイプ**: `Formatter`インターフェース、`HTMLFormatter`, `MarkdownFormatter`, `TextFormatter`, `JSONFormatter`
+
+## データフロー
+
+### 同期リクエストのライフサイクル
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant CLI
+    participant Config
+    participant API
+    participant UpstageAPI
+    participant Formatter
+    participant Output
+
+    User->>CLI: updoc parse document.pdf
+    CLI->>Config: 設定をロード
+    Config-->>CLI: マージされた設定
+    CLI->>API: APIキーでクライアントを作成
+    CLI->>API: Parse(file, options)
+    API->>API: マルチパートフォームを構築
+    API->>UpstageAPI: POST /document-digitization
+    UpstageAPI-->>API: ParseResponse
+    API-->>CLI: ParseResponse
+    CLI->>Formatter: Format(response, format)
+    Formatter-->>CLI: フォーマット済み文字列
+    CLI->>Output: ファイル/stdoutに書き込み
+    Output-->>User: 結果
+```
+
+### 非同期リクエストのライフサイクル
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant CLI
+    participant API
+    participant UpstageAPI
+
+    User->>CLI: updoc parse large.pdf --async
+    CLI->>API: ParseAsync(file, options)
+    API->>UpstageAPI: POST /document-digitization/async
+    UpstageAPI-->>API: AsyncResponse (request_id)
+    API-->>CLI: request_id
+    CLI-->>User: リクエストIDを表示
+
+    Note over User,UpstageAPI: ポーリングフェーズ
+
+    User->>CLI: updoc status request_id
+    CLI->>API: GetStatus(request_id)
+    API->>UpstageAPI: GET /document-digitization/async/{id}
+    UpstageAPI-->>API: StatusResponse
+    API-->>CLI: ステータス (pending/processing/completed)
+    CLI-->>User: ステータスを表示
+
+    Note over User,UpstageAPI: 結果取得
+
+    User->>CLI: updoc result request_id
+    CLI->>API: GetResult(request_id)
+    API->>UpstageAPI: GET /document-digitization/async/{id}/result
+    UpstageAPI-->>API: ParseResponse
+    API-->>CLI: ParseResponse
+    CLI->>Formatter: レスポンスをフォーマット
+    Formatter-->>CLI: フォーマット済み出力
+    CLI-->>User: 結果
+```
+
+### バッチ処理のフロー
+
+```mermaid
+graph TB
+    Start[パースコマンド] --> Collect[ファイルを収集]
+    Collect --> Check{複数のファイル?}
+    Check -->|単一| Single[単一ファイルを処理]
+    Check -->|複数| Batch[バッチ処理]
+    Batch --> Loop[各ファイルについて]
+    Loop --> Process[ファイルを処理]
+    Process --> Format[出力をフォーマット]
+    Format --> Write[出力ディレクトリに書き込み]
+    Write --> Next{さらにファイルがある?}
+    Next -->|はい| Loop
+    Next -->|いいえ| Summary[サマリーを出力]
+    Single --> FormatSingle[出力をフォーマット]
+    FormatSingle --> OutputSingle[ファイル/Stdoutに出力]
+    Summary --> End[完了]
+    OutputSingle --> End
+```
+
+## 設定階層
+
+設定値は次の順序で解決されます（優先度: 高 → 低）：
+
+1. **コマンドラインフラグ** - 直接ユーザー入力
+2. **環境変数** - システムレベルの設定
+3. **設定ファイル** - ユーザー固有のデフォルト
+4. **デフォルト値** - 組み込みデフォルト
+
+### 設定解決フロー
+
+```mermaid
+graph TB
+    Start[設定値を取得] --> CheckFlag{フラグが設定されている?}
+    CheckFlag -->|はい| UseFlag[フラグ値を使用]
+    CheckFlag -->|いいえ| CheckEnv{環境変数が設定されている?}
+    CheckEnv -->|はい| UseEnv[環境変数を使用]
+    CheckEnv -->|いいえ| CheckFile{設定ファイルの値?}
+    CheckFile -->|はい| UseFile[設定ファイルの値を使用]
+    CheckFile -->|いいえ| UseDefault[デフォルト値を使用]
+    UseFlag --> End[値を返す]
+    UseEnv --> End
+    UseFile --> End
+    UseDefault --> End
+```
+
+### 設定ソース
+
+#### 環境変数
+- `UPSTAGE_API_KEY` - API認証キー
+- `UPSTAGE_API_ENDPOINT` - カスタムAPIエンドポイント（プライベートホスティング用）
+- `UPDOC_CONFIG_PATH` - デフォルト設定ファイルパスをオーバーライド
+- `UPDOC_LOG_LEVEL` - ログレベル
+
+#### 設定ファイル (Linux/macOS: `~/.config/updoc/config.yaml`, Windows: `%APPDATA%\updoc\config.yaml`)
+```yaml
+api_key: "up_xxxxxxxxxxxx"
+endpoint: "https://api.upstage.ai/v1"
+default_format: "markdown"
+default_mode: "standard"
+default_ocr: "auto"
+output_dir: ""
+```
+
+#### コマンドラインフラグ
+- `--api-key` - APIキーをオーバーライド
+- `--endpoint` - APIエンドポイントをオーバーライド
+- `--format` - 出力形式をオーバーライド
+- `--mode` - パースモードをオーバーライド
+- `--ocr` - OCR設定をオーバーライド
+
+#### デフォルト値
+- 形式: `markdown`
+- モード: `standard`
+- OCR: `auto`
+- エンドポイント: `https://api.upstage.ai/v1`
+
+## エラーハンドリング戦略
+
+### エラータイプ
+
+#### 1. APIエラー (`internal/api`)
+- **タイプ**: `APIError`
+- **プロパティ**: StatusCode, Message, Type, Code
+- **処理**: コンテキストと共にラップして呼び出し元に返す
+- **ユーザーメッセージ**: ステータスコードを含む明確なエラーメッセージ
+
+```go
+type APIError struct {
+    StatusCode int
+    Message    string
+    Type       string
+    Code       string
+}
+```
+
+#### 2. 設定エラー (`internal/config`)
+- **タイプ**: `ErrUnknownKey`, `ErrInvalidFormat`, `ErrInvalidMode`, `ErrInvalidOCR`
+- **処理**: 説明的なエラーメッセージと共に即座に返す
+- **ユーザーメッセージ**: 特定の検証エラー
+
+#### 3. ファイルシステムエラー (`internal/cmd`)
+- **タイプ**: 標準Goエラー (`os.PathError`, `os.ErrNotExist`)
+- **処理**: 操作のコンテキストと共にラップ
+- **ユーザーメッセージ**: ファイルパスと操作コンテキスト
+
+#### 4. 検証エラー (`internal/cmd`)
+- **タイプ**: カスタムエラーメッセージ
+- **処理**: API呼び出し前に返す
+- **ユーザーメッセージ**: 問題点と修正方法に関する明確なガイダンス
+
+### エラーハンドリングパターン
+
+#### パターン1: 早期検証
+```go
+// 処理前に検証
+if apiKey == "" {
+    return fmt.Errorf("API key not set. Set it with 'updoc config set api-key <your-key>'")
+}
+```
+
+#### パターン2: エラーラッピング
+```go
+// コンテキストと共にエラーをラップ
+if err != nil {
+    return fmt.Errorf("parse failed: %w", err)
+}
+```
+
+#### パターン3: ユーザーフレンドリーなメッセージ
+```go
+// 技術的エラーをユーザーフレンドリーなメッセージに変換
+if apiErr, ok := err.(*api.APIError); ok {
+    return fmt.Errorf("API error: %s", apiErr.Message)
+}
+```
+
+### エラーフロー
+
+```mermaid
+graph TB
+    Error[エラー発生] --> Type{エラータイプ?}
+    Type -->|APIエラー| APIErr[APIError]
+    Type -->|設定エラー| ConfigErr[ConfigError]
+    Type -->|ファイルエラー| FileErr[FileError]
+    Type -->|検証エラー| ValErr[ValidationError]
+    
+    APIErr --> Wrap[コンテキストと共にラップ]
+    ConfigErr --> Wrap
+    FileErr --> Wrap
+    ValErr --> Wrap
+    
+    Wrap --> UserMsg[ユーザーメッセージを生成]
+    UserMsg --> CLI[CLIエラーハンドラー]
+    CLI --> Stderr[stderrに書き込み]
+    Stderr --> Exit[コード1で終了]
+```
+
+## 拡張ポイント
+
+### 新しい出力形式の追加
+
+新しい出力形式を追加するには：
+
+1. **`internal/output/formatter.go`で`Formatter`インターフェースを実装**:
+```go
+type CustomFormatter struct{}
+
+func (f *CustomFormatter) Format(resp *api.ParseResponse) (string, error) {
+    // respをカスタム形式に変換
+    return formattedString, nil
+}
+```
+
+2. **`NewFormatter`関数に登録**:
+```go
+func NewFormatter(format string) (Formatter, error) {
+    switch format {
+    // ... 既存のケース
+    case "custom":
+        return &CustomFormatter{}, nil
+    }
+}
+```
+
+3. **`internal/config/config.go`で形式検証を追加**:
+```go
+ValidFormats = []string{"html", "markdown", "text", "custom"}
+```
+
+4. **`internal/cmd/parse.go`でCLIヘルプテキストを更新**:
+```go
+parseCmd.Flags().StringP("format", "f", "", "output format: html, markdown, text, custom")
+```
+
+### 新しいコマンドの追加
+
+新しいコマンドを追加するには：
+
+1. **`internal/cmd/`にコマンドファイルを作成**:
+```go
+package cmd
+
+import "github.com/spf13/cobra"
+
+var newCmd = &cobra.Command{
+    Use:   "new <args>",
+    Short: "コマンドの説明",
+    Long:  "詳細な説明",
+    RunE:  runNew,
+}
+
+func init() {
+    newCmd.Flags().StringP("flag", "f", "", "フラグの説明")
+    rootCmd.AddCommand(newCmd)
+}
+
+func runNew(cmd *cobra.Command, args []string) error {
+    // コマンドの実装
+    return nil
+}
+```
+
+2. **新しいファイルの`init()`関数でコマンドを登録**
+
+3. **ドキュメントを更新**:
+   - `docs/CLI_MANUAL.md`に追加
+   - `README.md`のコマンドサマリーを更新
+
+### 新しい設定オプションの追加
+
+新しい設定オプションを追加するには：
+
+1. **`internal/config/config.go`の`Config`構造体にフィールドを追加**:
+```go
+type Config struct {
+    // ... 既存のフィールド
+    NewOption string `yaml:"new_option"`
+}
+```
+
+2. **デフォルト値を追加**:
+```go
+const DefaultNewOption = "default_value"
+```
+
+3. **`Set`および`Get`メソッドを更新**:
+```go
+func (c *Config) Set(key, value string) error {
+    switch key {
+    // ... 既存のケース
+    case "new-option":
+        c.NewOption = value
+    }
+}
+
+func (c *Config) Get(key string) (string, error) {
+    switch key {
+    // ... 既存のケース
+    case "new-option":
+        return c.NewOption, nil
+    }
+}
+```
+
+4. **`New`および`Reset`メソッドを更新して新しいフィールドを含める**
+
+5. **必要に応じて`internal/cmd/root.go`またはコマンド固有のファイルにCLIフラグを追加**
+
+6. **`docs/CLI_MANUAL.md`でドキュメントを更新**
+
+### APIクライアントの拡張
+
+新しいAPIエンドポイントを追加するには：
+
+1. **`internal/api/types.go`にリクエスト/レスポンスタイプを追加**:
+```go
+type NewRequest struct {
+    // リクエストフィールド
+}
+
+type NewResponse struct {
+    // レスポンスフィールド
+}
+```
+
+2. **`internal/api/client.go`にクライアントメソッドを追加**:
+```go
+func (c *Client) NewOperation(ctx context.Context, req *NewRequest) (*NewResponse, error) {
+    // リクエストを構築
+    // HTTPリクエストを送信
+    // レスポンスをパース
+    // 結果を返す
+}
+```
+
+3. **必要に応じてコマンドで使用**
+
+## 設計決定
+
+### CLIにCobraを使用する理由？
+- Go CLIアプリケーションの業界標準
+- 優れたフラグパースと検証
+- 組み込みヘルプ生成
+- 簡単なコマンド構成
+
+### 別のAPIクライアントパッケージを使用する理由？
+- 関心の分離
+- テストの容易性（APIクライアントをモック可能）
+- APIクライアントが他の場所で必要な場合の再利用性
+- 明確なAPI境界
+
+### 設定階層を使用する理由？
+- 柔軟性: ユーザーが異なるレベルでデフォルトをオーバーライド可能
+- セキュリティ: 機密値（APIキー）は環境変数から取得可能
+- 利便性: 一般的な設定を設定ファイルに保存可能
+- 予測可能性: 明確な優先順位ルール
+
+### Formatterインターフェースを使用する理由？
+- 新しい出力形式の追加が容易
+- テスト可能（フォーマッターを独立してテスト可能）
+- Open/Closed原則に準拠
+- APIレスポンスと出力形式の明確な分離
+
+## テスト戦略
+
+### 単体テスト
+- 各パッケージに対応する`*_test.go`ファイル
+- 個々のコンポーネントを分離してテスト
+- 外部依存関係をモック（HTTPクライアント、ファイルシステム）
+
+### 統合テスト
+- コンポーネント間の相互作用をテスト
+- `test/testdata/`のテストフィクスチャを使用
+
+### エンドツーエンドテスト
+- `test/e2e/`に配置
+- 有効なAPIキーが必要
+- CLIからAPIまでの完全なワークフローをテスト
+
+## 今後の考慮事項
+
+- **プラグインシステム**: プラグインを通じた外部フォーマッターの許可
+- **ストリーミング出力**: 大規模ドキュメントのストリーミングサポート
+- **リトライロジック**: 一時的なAPIエラーに対する自動リトライ
+- **レート制限**: API呼び出しに対するクライアント側のレート制限
+- **キャッシング**: 繰り返しリクエストに対するAPIレスポンスのキャッシング
+- **進捗インジケーター**: バッチ操作に対するより良い進捗レポート

--- a/docs/ARCHITECTURE.ko.md
+++ b/docs/ARCHITECTURE.ko.md
@@ -1,0 +1,545 @@
+# 아키텍처 문서
+
+[English](ARCHITECTURE.md) | [日本語](ARCHITECTURE.ja.md)
+
+이 문서는 `updoc` CLI 도구의 전체 아키텍처, 설계 결정사항, 컴포넌트 상호작용을 설명합니다.
+
+## 목차
+
+- [시스템 개요](#시스템-개요)
+- [패키지 구조](#패키지-구조)
+- [데이터 흐름](#데이터-흐름)
+- [설정 계층 구조](#설정-계층-구조)
+- [에러 처리 전략](#에러-처리-전략)
+- [확장 포인트](#확장-포인트)
+
+## 시스템 개요
+
+`updoc`은 Upstage Document Parse API를 위한 명령줄 인터페이스입니다. 동기 및 비동기 API 호출을 통해 문서(PDF, Office 파일, 이미지)를 구조화된 텍스트 형식(HTML, Markdown, Text)으로 변환하는 간단한 방법을 제공합니다.
+
+### 고수준 아키텍처
+
+```mermaid
+graph TB
+    User[사용자] --> CLI[CLI 명령어]
+    CLI --> Config[설정 관리자]
+    CLI --> API[API 클라이언트]
+    API --> HTTP[HTTP 클라이언트]
+    HTTP --> UpstageAPI[Upstage API]
+    UpstageAPI --> HTTP
+    HTTP --> API
+    API --> Response[파싱 응답]
+    Response --> Formatter[출력 포맷터]
+    Formatter --> Output[포맷된 출력]
+    Output --> User
+    
+    Config --> EnvVars[환경 변수]
+    Config --> ConfigFile[설정 파일]
+    Config --> CLI
+```
+
+### 컴포넌트 책임
+
+| 컴포넌트 | 책임 |
+|----------|------|
+| **CLI 명령어** (`internal/cmd`) | 사용자 입력 파싱, 인자 검증, 워크플로우 조율 |
+| **API 클라이언트** (`internal/api`) | Upstage API와의 HTTP 통신 처리, 요청/응답 생명주기 관리 |
+| **설정 관리자** (`internal/config`) | 여러 소스(환경 변수, 설정 파일, CLI 플래그)에서 설정 로드 및 병합 |
+| **출력 포맷터** (`internal/output`) | API 응답을 사용자 요청 형식(HTML, Markdown, Text, JSON)으로 변환 |
+| **진입점** (`cmd/updoc`) | CLI 프레임워크 초기화 및 애플리케이션 생명주기 처리 |
+
+## 패키지 구조
+
+```
+updoc/
+├── cmd/updoc/              # 애플리케이션 진입점
+│   └── main.go            # CLI 초기화 및 에러 처리
+│
+├── internal/
+│   ├── api/               # Upstage API 클라이언트
+│   │   ├── client.go      # HTTP 클라이언트 구현
+│   │   └── types.go       # API 요청/응답 타입
+│   │
+│   ├── cmd/               # CLI 명령어 구현
+│   │   ├── root.go        # 루트 명령어 및 공유 유틸리티
+│   │   ├── parse.go       # 파싱 명령어 (동기/비동기)
+│   │   ├── status.go      # 상태 확인 명령어
+│   │   ├── result.go      # 결과 조회 명령어
+│   │   ├── config.go      # 설정 관리 명령어
+│   │   ├── models.go      # 모델 목록 명령어
+│   │   └── version.go     # 버전 명령어
+│   │
+│   ├── config/            # 설정 관리
+│   │   └── config.go      # 설정 로드, 저장, 검증
+│   │
+│   └── output/            # 출력 포맷팅
+│       └── formatter.go   # 포맷 변환기 (HTML, Markdown, Text, JSON)
+│
+├── test/                  # 테스트 파일
+│   ├── e2e/              # 엔드투엔드 테스트
+│   └── testdata/         # 테스트 픽스처
+│
+└── docs/                  # 문서
+    ├── ARCHITECTURE.md   # 이 파일
+    └── CLI_MANUAL.md     # CLI 참조
+```
+
+### 패키지 상세
+
+#### `cmd/updoc`
+- **목적**: 애플리케이션 진입점
+- **책임**: Cobra CLI 프레임워크 초기화, 최상위 에러 처리
+- **의존성**: `internal/cmd`
+
+#### `internal/api`
+- **목적**: Upstage API 클라이언트 추상화
+- **책임**:
+  - HTTP 요청 생성 (파일 업로드를 위한 멀티파트 폼 데이터)
+  - API 인증 처리 (Bearer 토큰)
+  - API 응답 및 에러 파싱
+  - 동기 및 비동기 작업 지원
+- **주요 타입**: `Client`, `ParseRequest`, `ParseResponse`, `AsyncResponse`, `StatusResponse`
+
+#### `internal/cmd`
+- **목적**: CLI 명령어 구현
+- **책임**:
+  - 명령어 구조 및 플래그 정의
+  - 사용자 입력 검증
+  - API 클라이언트, 설정, 출력 포맷터 간 조율
+  - 배치 처리 처리
+  - 비동기 워크플로우 관리 (파싱 → 상태 → 결과)
+- **주요 명령어**: `parse`, `status`, `result`, `config`, `models`, `version`
+
+#### `internal/config`
+- **목적**: 설정 관리
+- **책임**:
+  - YAML 파일에서 설정 로드
+  - 환경 변수에서 설정 병합
+  - 설정 계층 구조 해결 제공
+  - 설정 값 검증
+  - 설정 파일에 저장
+- **주요 타입**: `Config`
+
+#### `internal/output`
+- **목적**: 출력 포맷팅
+- **책임**:
+  - API 응답을 요청된 형식으로 변환
+  - 여러 출력 형식 지원 (HTML, Markdown, Text, JSON)
+  - 요소 전용 출력 모드 처리
+- **주요 타입**: `Formatter` 인터페이스, `HTMLFormatter`, `MarkdownFormatter`, `TextFormatter`, `JSONFormatter`
+
+## 데이터 흐름
+
+### 동기 요청 생명주기
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant CLI
+    participant Config
+    participant API
+    participant UpstageAPI
+    participant Formatter
+    participant Output
+
+    User->>CLI: updoc parse document.pdf
+    CLI->>Config: 설정 로드
+    Config-->>CLI: 병합된 설정
+    CLI->>API: API 키로 클라이언트 생성
+    CLI->>API: Parse(file, options)
+    API->>API: 멀티파트 폼 생성
+    API->>UpstageAPI: POST /document-digitization
+    UpstageAPI-->>API: ParseResponse
+    API-->>CLI: ParseResponse
+    CLI->>Formatter: Format(response, format)
+    Formatter-->>CLI: 포맷된 문자열
+    CLI->>Output: 파일/stdout에 쓰기
+    Output-->>User: 결과
+```
+
+### 비동기 요청 생명주기
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant CLI
+    participant API
+    participant UpstageAPI
+
+    User->>CLI: updoc parse large.pdf --async
+    CLI->>API: ParseAsync(file, options)
+    API->>UpstageAPI: POST /document-digitization/async
+    UpstageAPI-->>API: AsyncResponse (request_id)
+    API-->>CLI: request_id
+    CLI-->>User: 요청 ID 표시
+
+    Note over User,UpstageAPI: 폴링 단계
+
+    User->>CLI: updoc status request_id
+    CLI->>API: GetStatus(request_id)
+    API->>UpstageAPI: GET /document-digitization/async/{id}
+    UpstageAPI-->>API: StatusResponse
+    API-->>CLI: 상태 (pending/processing/completed)
+    CLI-->>User: 상태 표시
+
+    Note over User,UpstageAPI: 결과 조회
+
+    User->>CLI: updoc result request_id
+    CLI->>API: GetResult(request_id)
+    API->>UpstageAPI: GET /document-digitization/async/{id}/result
+    UpstageAPI-->>API: ParseResponse
+    API-->>CLI: ParseResponse
+    CLI->>Formatter: 응답 포맷팅
+    Formatter-->>CLI: 포맷된 출력
+    CLI-->>User: 결과
+```
+
+### 배치 처리 흐름
+
+```mermaid
+graph TB
+    Start[파싱 명령어] --> Collect[파일 수집]
+    Collect --> Check{여러 파일?}
+    Check -->|단일| Single[단일 파일 처리]
+    Check -->|여러| Batch[배치 처리]
+    Batch --> Loop[각 파일에 대해]
+    Loop --> Process[파일 처리]
+    Process --> Format[출력 포맷팅]
+    Format --> Write[출력 디렉토리에 쓰기]
+    Write --> Next{더 많은 파일?}
+    Next -->|예| Loop
+    Next -->|아니오| Summary[요약 출력]
+    Single --> FormatSingle[출력 포맷팅]
+    FormatSingle --> OutputSingle[파일/Stdout에 출력]
+    Summary --> End[완료]
+    OutputSingle --> End
+```
+
+## 설정 계층 구조
+
+설정 값은 다음 순서로 해결됩니다 (우선순위 높음 → 낮음):
+
+1. **명령줄 플래그** - 직접 사용자 입력
+2. **환경 변수** - 시스템 수준 설정
+3. **설정 파일** - 사용자별 기본값
+4. **기본값** - 내장 기본값
+
+### 설정 해결 흐름
+
+```mermaid
+graph TB
+    Start[설정 값 가져오기] --> CheckFlag{플래그 설정?}
+    CheckFlag -->|예| UseFlag[플래그 값 사용]
+    CheckFlag -->|아니오| CheckEnv{환경 변수 설정?}
+    CheckEnv -->|예| UseEnv[환경 변수 사용]
+    CheckEnv -->|아니오| CheckFile{설정 파일 값?}
+    CheckFile -->|예| UseFile[설정 파일 값 사용]
+    CheckFile -->|아니오| UseDefault[기본값 사용]
+    UseFlag --> End[값 반환]
+    UseEnv --> End
+    UseFile --> End
+    UseDefault --> End
+```
+
+### 설정 소스
+
+#### 환경 변수
+- `UPSTAGE_API_KEY` - API 인증 키
+- `UPSTAGE_API_ENDPOINT` - 사용자 정의 API 엔드포인트 (프라이빗 호스팅용)
+- `UPDOC_CONFIG_PATH` - 기본 설정 파일 경로 재정의
+- `UPDOC_LOG_LEVEL` - 로깅 수준
+
+#### 설정 파일 (Linux/macOS: `~/.config/updoc/config.yaml`, Windows: `%APPDATA%\updoc\config.yaml`)
+```yaml
+api_key: "up_xxxxxxxxxxxx"
+endpoint: "https://api.upstage.ai/v1"
+default_format: "markdown"
+default_mode: "standard"
+default_ocr: "auto"
+output_dir: ""
+```
+
+#### 명령줄 플래그
+- `--api-key` - API 키 재정의
+- `--endpoint` - API 엔드포인트 재정의
+- `--format` - 출력 형식 재정의
+- `--mode` - 파싱 모드 재정의
+- `--ocr` - OCR 설정 재정의
+
+#### 기본값
+- 형식: `markdown`
+- 모드: `standard`
+- OCR: `auto`
+- 엔드포인트: `https://api.upstage.ai/v1`
+
+## 에러 처리 전략
+
+### 에러 타입
+
+#### 1. API 에러 (`internal/api`)
+- **타입**: `APIError`
+- **속성**: StatusCode, Message, Type, Code
+- **처리**: 컨텍스트와 함께 래핑하여 호출자에게 반환
+- **사용자 메시지**: 상태 코드가 포함된 명확한 에러 메시지
+
+```go
+type APIError struct {
+    StatusCode int
+    Message    string
+    Type       string
+    Code       string
+}
+```
+
+#### 2. 설정 에러 (`internal/config`)
+- **타입**: `ErrUnknownKey`, `ErrInvalidFormat`, `ErrInvalidMode`, `ErrInvalidOCR`
+- **처리**: 설명적인 에러 메시지와 함께 즉시 반환
+- **사용자 메시지**: 특정 검증 에러
+
+#### 3. 파일 시스템 에러 (`internal/cmd`)
+- **타입**: 표준 Go 에러 (`os.PathError`, `os.ErrNotExist`)
+- **처리**: 작업 컨텍스트와 함께 래핑
+- **사용자 메시지**: 파일 경로 및 작업 컨텍스트
+
+#### 4. 검증 에러 (`internal/cmd`)
+- **타입**: 사용자 정의 에러 메시지
+- **처리**: API 호출 전에 반환
+- **사용자 메시지**: 문제점과 해결 방법에 대한 명확한 안내
+
+### 에러 처리 패턴
+
+#### 패턴 1: 조기 검증
+```go
+// 처리 전 검증
+if apiKey == "" {
+    return fmt.Errorf("API key not set. Set it with 'updoc config set api-key <your-key>'")
+}
+```
+
+#### 패턴 2: 에러 래핑
+```go
+// 컨텍스트와 함께 에러 래핑
+if err != nil {
+    return fmt.Errorf("parse failed: %w", err)
+}
+```
+
+#### 패턴 3: 사용자 친화적 메시지
+```go
+// 기술적 에러를 사용자 친화적 메시지로 변환
+if apiErr, ok := err.(*api.APIError); ok {
+    return fmt.Errorf("API error: %s", apiErr.Message)
+}
+```
+
+### 에러 흐름
+
+```mermaid
+graph TB
+    Error[에러 발생] --> Type{에러 타입?}
+    Type -->|API 에러| APIErr[APIError]
+    Type -->|설정 에러| ConfigErr[ConfigError]
+    Type -->|파일 에러| FileErr[FileError]
+    Type -->|검증 에러| ValErr[ValidationError]
+    
+    APIErr --> Wrap[컨텍스트와 함께 래핑]
+    ConfigErr --> Wrap
+    FileErr --> Wrap
+    ValErr --> Wrap
+    
+    Wrap --> UserMsg[사용자 메시지 생성]
+    UserMsg --> CLI[CLI 에러 핸들러]
+    CLI --> Stderr[stderr에 쓰기]
+    Stderr --> Exit[코드 1로 종료]
+```
+
+## 확장 포인트
+
+### 새로운 출력 형식 추가
+
+새로운 출력 형식을 추가하려면:
+
+1. **`internal/output/formatter.go`에서 `Formatter` 인터페이스 구현**:
+```go
+type CustomFormatter struct{}
+
+func (f *CustomFormatter) Format(resp *api.ParseResponse) (string, error) {
+    // resp를 사용자 정의 형식으로 변환
+    return formattedString, nil
+}
+```
+
+2. **`NewFormatter` 함수에 등록**:
+```go
+func NewFormatter(format string) (Formatter, error) {
+    switch format {
+    // ... 기존 케이스
+    case "custom":
+        return &CustomFormatter{}, nil
+    }
+}
+```
+
+3. **`internal/config/config.go`에서 형식 검증 추가**:
+```go
+ValidFormats = []string{"html", "markdown", "text", "custom"}
+```
+
+4. **`internal/cmd/parse.go`에서 CLI 도움말 텍스트 업데이트**:
+```go
+parseCmd.Flags().StringP("format", "f", "", "output format: html, markdown, text, custom")
+```
+
+### 새로운 명령어 추가
+
+새로운 명령어를 추가하려면:
+
+1. **`internal/cmd/`에 명령어 파일 생성**:
+```go
+package cmd
+
+import "github.com/spf13/cobra"
+
+var newCmd = &cobra.Command{
+    Use:   "new <args>",
+    Short: "명령어 설명",
+    Long:  "상세 설명",
+    RunE:  runNew,
+}
+
+func init() {
+    newCmd.Flags().StringP("flag", "f", "", "플래그 설명")
+    rootCmd.AddCommand(newCmd)
+}
+
+func runNew(cmd *cobra.Command, args []string) error {
+    // 명령어 구현
+    return nil
+}
+```
+
+2. **새 파일의 `init()` 함수에서 명령어 등록**
+
+3. **문서 업데이트**:
+   - `docs/CLI_MANUAL.md`에 추가
+   - `README.md` 명령어 요약 업데이트
+
+### 새로운 설정 옵션 추가
+
+새로운 설정 옵션을 추가하려면:
+
+1. **`internal/config/config.go`의 `Config` 구조체에 필드 추가**:
+```go
+type Config struct {
+    // ... 기존 필드
+    NewOption string `yaml:"new_option"`
+}
+```
+
+2. **기본값 추가**:
+```go
+const DefaultNewOption = "default_value"
+```
+
+3. **`Set` 및 `Get` 메서드 업데이트**:
+```go
+func (c *Config) Set(key, value string) error {
+    switch key {
+    // ... 기존 케이스
+    case "new-option":
+        c.NewOption = value
+    }
+}
+
+func (c *Config) Get(key string) (string, error) {
+    switch key {
+    // ... 기존 케이스
+    case "new-option":
+        return c.NewOption, nil
+    }
+}
+```
+
+4. **`New` 및 `Reset` 메서드를 업데이트하여 새 필드 포함**
+
+5. **필요한 경우 `internal/cmd/root.go` 또는 명령어별 파일에 CLI 플래그 추가**
+
+6. **`docs/CLI_MANUAL.md`에서 문서 업데이트**
+
+### API 클라이언트 확장
+
+새로운 API 엔드포인트를 추가하려면:
+
+1. **`internal/api/types.go`에 요청/응답 타입 추가**:
+```go
+type NewRequest struct {
+    // 요청 필드
+}
+
+type NewResponse struct {
+    // 응답 필드
+}
+```
+
+2. **`internal/api/client.go`에 클라이언트 메서드 추가**:
+```go
+func (c *Client) NewOperation(ctx context.Context, req *NewRequest) (*NewResponse, error) {
+    // 요청 생성
+    // HTTP 요청 전송
+    // 응답 파싱
+    // 결과 반환
+}
+```
+
+3. **필요에 따라 명령어에서 사용**
+
+## 설계 결정
+
+### CLI에 Cobra를 사용하는 이유?
+- Go CLI 애플리케이션의 업계 표준
+- 우수한 플래그 파싱 및 검증
+- 내장 도움말 생성
+- 쉬운 명령어 구성
+
+### 별도의 API 클라이언트 패키지를 사용하는 이유?
+- 관심사 분리
+- 테스트 용이성 (API 클라이언트 모킹 가능)
+- API 클라이언트가 다른 곳에서 필요한 경우 재사용성
+- 명확한 API 경계
+
+### 설정 계층 구조를 사용하는 이유?
+- 유연성: 사용자가 다른 수준에서 기본값을 재정의할 수 있음
+- 보안: 민감한 값(API 키)은 환경 변수에서 올 수 있음
+- 편의성: 일반적인 설정을 설정 파일에 저장할 수 있음
+- 예측 가능성: 명확한 우선순위 규칙
+
+### Formatter 인터페이스를 사용하는 이유?
+- 새로운 출력 형식 추가 용이
+- 테스트 가능 (포맷터를 독립적으로 테스트 가능)
+- Open/Closed 원칙 준수
+- API 응답과 출력 형식 간 명확한 분리
+
+## 테스트 전략
+
+### 단위 테스트
+- 각 패키지에 해당하는 `*_test.go` 파일
+- 개별 컴포넌트를 격리하여 테스트
+- 외부 의존성 모킹 (HTTP 클라이언트, 파일 시스템)
+
+### 통합 테스트
+- 컴포넌트 상호작용 테스트
+- `test/testdata/`의 테스트 픽스처 사용
+
+### 엔드투엔드 테스트
+- `test/e2e/`에 위치
+- 유효한 API 키 필요
+- CLI에서 API까지 전체 워크플로우 테스트
+
+## 향후 고려사항
+
+- **플러그인 시스템**: 플러그인을 통한 외부 포맷터 허용
+- **스트리밍 출력**: 대용량 문서에 대한 스트리밍 지원
+- **재시도 로직**: 일시적 API 에러에 대한 자동 재시도
+- **속도 제한**: API 호출에 대한 클라이언트 측 속도 제한
+- **캐싱**: 반복 요청에 대한 API 응답 캐싱
+- **진행 표시기**: 배치 작업에 대한 더 나은 진행 보고

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,545 @@
+# Architecture Documentation
+
+[한국어](ARCHITECTURE.ko.md) | [日本語](ARCHITECTURE.ja.md)
+
+This document describes the overall architecture, design decisions, and component interactions of the `updoc` CLI tool.
+
+## Table of Contents
+
+- [System Overview](#system-overview)
+- [Package Structure](#package-structure)
+- [Data Flow](#data-flow)
+- [Configuration Hierarchy](#configuration-hierarchy)
+- [Error Handling Strategy](#error-handling-strategy)
+- [Extension Points](#extension-points)
+
+## System Overview
+
+`updoc` is a command-line interface for the Upstage Document Parse API. It provides a simple way to convert documents (PDF, Office files, images) into structured text formats (HTML, Markdown, Text) through both synchronous and asynchronous API calls.
+
+### High-Level Architecture
+
+```mermaid
+graph TB
+    User[User] --> CLI[CLI Commands]
+    CLI --> Config[Configuration Manager]
+    CLI --> API[API Client]
+    API --> HTTP[HTTP Client]
+    HTTP --> UpstageAPI[Upstage API]
+    UpstageAPI --> HTTP
+    HTTP --> API
+    API --> Response[Parse Response]
+    Response --> Formatter[Output Formatter]
+    Formatter --> Output[Formatted Output]
+    Output --> User
+    
+    Config --> EnvVars[Environment Variables]
+    Config --> ConfigFile[Config File]
+    Config --> CLI
+```
+
+### Component Responsibilities
+
+| Component | Responsibility |
+|-----------|---------------|
+| **CLI Commands** (`internal/cmd`) | Parse user input, validate arguments, orchestrate workflow |
+| **API Client** (`internal/api`) | Handle HTTP communication with Upstage API, manage request/response lifecycle |
+| **Configuration Manager** (`internal/config`) | Load and merge configuration from multiple sources (env vars, config file, CLI flags) |
+| **Output Formatter** (`internal/output`) | Transform API responses into user-requested formats (HTML, Markdown, Text, JSON) |
+| **Entry Point** (`cmd/updoc`) | Initialize CLI framework and handle application lifecycle |
+
+## Package Structure
+
+```
+updoc/
+├── cmd/updoc/              # Application entry point
+│   └── main.go            # Initializes CLI and handles errors
+│
+├── internal/
+│   ├── api/               # Upstage API client
+│   │   ├── client.go      # HTTP client implementation
+│   │   └── types.go       # API request/response types
+│   │
+│   ├── cmd/               # CLI command implementations
+│   │   ├── root.go        # Root command and shared utilities
+│   │   ├── parse.go       # Parse command (sync/async)
+│   │   ├── status.go      # Status check command
+│   │   ├── result.go      # Result retrieval command
+│   │   ├── config.go      # Configuration management command
+│   │   ├── models.go      # Models listing command
+│   │   └── version.go     # Version command
+│   │
+│   ├── config/            # Configuration management
+│   │   └── config.go      # Config loading, saving, validation
+│   │
+│   └── output/            # Output formatting
+│       └── formatter.go   # Format converters (HTML, Markdown, Text, JSON)
+│
+├── test/                  # Test files
+│   ├── e2e/              # End-to-end tests
+│   └── testdata/         # Test fixtures
+│
+└── docs/                  # Documentation
+    ├── ARCHITECTURE.md   # This file
+    └── CLI_MANUAL.md     # CLI reference
+```
+
+### Package Details
+
+#### `cmd/updoc`
+- **Purpose**: Application entry point
+- **Responsibilities**: Initialize Cobra CLI framework, handle top-level errors
+- **Dependencies**: `internal/cmd`
+
+#### `internal/api`
+- **Purpose**: Upstage API client abstraction
+- **Responsibilities**:
+  - Build HTTP requests (multipart form data for file uploads)
+  - Handle API authentication (Bearer token)
+  - Parse API responses and errors
+  - Support both sync and async operations
+- **Key Types**: `Client`, `ParseRequest`, `ParseResponse`, `AsyncResponse`, `StatusResponse`
+
+#### `internal/cmd`
+- **Purpose**: CLI command implementations
+- **Responsibilities**:
+  - Define command structure and flags
+  - Validate user input
+  - Coordinate between API client, config, and output formatters
+  - Handle batch processing
+  - Manage async workflow (parse → status → result)
+- **Key Commands**: `parse`, `status`, `result`, `config`, `models`, `version`
+
+#### `internal/config`
+- **Purpose**: Configuration management
+- **Responsibilities**:
+  - Load configuration from YAML file
+  - Merge configuration from environment variables
+  - Provide configuration hierarchy resolution
+  - Validate configuration values
+  - Save configuration to file
+- **Key Types**: `Config`
+
+#### `internal/output`
+- **Purpose**: Output formatting
+- **Responsibilities**:
+  - Convert API responses to requested formats
+  - Support multiple output formats (HTML, Markdown, Text, JSON)
+  - Handle elements-only output mode
+- **Key Types**: `Formatter` interface, `HTMLFormatter`, `MarkdownFormatter`, `TextFormatter`, `JSONFormatter`
+
+## Data Flow
+
+### Synchronous Request Lifecycle
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant CLI
+    participant Config
+    participant API
+    participant UpstageAPI
+    participant Formatter
+    participant Output
+
+    User->>CLI: updoc parse document.pdf
+    CLI->>Config: Load configuration
+    Config-->>CLI: Merged config
+    CLI->>API: Create client with API key
+    CLI->>API: Parse(file, options)
+    API->>API: Build multipart form
+    API->>UpstageAPI: POST /document-digitization
+    UpstageAPI-->>API: ParseResponse
+    API-->>CLI: ParseResponse
+    CLI->>Formatter: Format(response, format)
+    Formatter-->>CLI: Formatted string
+    CLI->>Output: Write to file/stdout
+    Output-->>User: Result
+```
+
+### Asynchronous Request Lifecycle
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant CLI
+    participant API
+    participant UpstageAPI
+
+    User->>CLI: updoc parse large.pdf --async
+    CLI->>API: ParseAsync(file, options)
+    API->>UpstageAPI: POST /document-digitization/async
+    UpstageAPI-->>API: AsyncResponse (request_id)
+    API-->>CLI: request_id
+    CLI-->>User: Request ID displayed
+
+    Note over User,UpstageAPI: Polling phase
+
+    User->>CLI: updoc status request_id
+    CLI->>API: GetStatus(request_id)
+    API->>UpstageAPI: GET /document-digitization/async/{id}
+    UpstageAPI-->>API: StatusResponse
+    API-->>CLI: Status (pending/processing/completed)
+    CLI-->>User: Status displayed
+
+    Note over User,UpstageAPI: Result retrieval
+
+    User->>CLI: updoc result request_id
+    CLI->>API: GetResult(request_id)
+    API->>UpstageAPI: GET /document-digitization/async/{id}/result
+    UpstageAPI-->>API: ParseResponse
+    API-->>CLI: ParseResponse
+    CLI->>Formatter: Format response
+    Formatter-->>CLI: Formatted output
+    CLI-->>User: Result
+```
+
+### Batch Processing Flow
+
+```mermaid
+graph TB
+    Start[Parse Command] --> Collect[Collect Files]
+    Collect --> Check{Multiple Files?}
+    Check -->|Single| Single[Process Single File]
+    Check -->|Multiple| Batch[Batch Processing]
+    Batch --> Loop[For each file]
+    Loop --> Process[Process File]
+    Process --> Format[Format Output]
+    Format --> Write[Write to Output Dir]
+    Write --> Next{More files?}
+    Next -->|Yes| Loop
+    Next -->|No| Summary[Print Summary]
+    Single --> FormatSingle[Format Output]
+    FormatSingle --> OutputSingle[Output to File/Stdout]
+    Summary --> End[Complete]
+    OutputSingle --> End
+```
+
+## Configuration Hierarchy
+
+Configuration values are resolved in the following order (highest to lowest priority):
+
+1. **Command-line flags** - Direct user input
+2. **Environment variables** - System-level configuration
+3. **Config file** - User-specific defaults
+4. **Default values** - Built-in defaults
+
+### Configuration Resolution Flow
+
+```mermaid
+graph TB
+    Start[Get Configuration Value] --> CheckFlag{Flag Set?}
+    CheckFlag -->|Yes| UseFlag[Use Flag Value]
+    CheckFlag -->|No| CheckEnv{Env Var Set?}
+    CheckEnv -->|Yes| UseEnv[Use Env Var]
+    CheckEnv -->|No| CheckFile{Config File Value?}
+    CheckFile -->|Yes| UseFile[Use Config File Value]
+    CheckFile -->|No| UseDefault[Use Default Value]
+    UseFlag --> End[Return Value]
+    UseEnv --> End
+    UseFile --> End
+    UseDefault --> End
+```
+
+### Configuration Sources
+
+#### Environment Variables
+- `UPSTAGE_API_KEY` - API authentication key
+- `UPSTAGE_API_ENDPOINT` - Custom API endpoint (for private hosting)
+- `UPDOC_CONFIG_PATH` - Override default config file path
+- `UPDOC_LOG_LEVEL` - Logging level
+
+#### Config File (`~/.config/updoc/config.yaml` on Linux/macOS, `%APPDATA%\updoc\config.yaml` on Windows)
+```yaml
+api_key: "up_xxxxxxxxxxxx"
+endpoint: "https://api.upstage.ai/v1"
+default_format: "markdown"
+default_mode: "standard"
+default_ocr: "auto"
+output_dir: ""
+```
+
+#### Command-Line Flags
+- `--api-key` - Override API key
+- `--endpoint` - Override API endpoint
+- `--format` - Override output format
+- `--mode` - Override parsing mode
+- `--ocr` - Override OCR setting
+
+#### Default Values
+- Format: `markdown`
+- Mode: `standard`
+- OCR: `auto`
+- Endpoint: `https://api.upstage.ai/v1`
+
+## Error Handling Strategy
+
+### Error Types
+
+#### 1. API Errors (`internal/api`)
+- **Type**: `APIError`
+- **Properties**: StatusCode, Message, Type, Code
+- **Handling**: Wrapped with context and returned to caller
+- **User Message**: Clear error message with status code
+
+```go
+type APIError struct {
+    StatusCode int
+    Message    string
+    Type       string
+    Code       string
+}
+```
+
+#### 2. Configuration Errors (`internal/config`)
+- **Type**: `ErrUnknownKey`, `ErrInvalidFormat`, `ErrInvalidMode`, `ErrInvalidOCR`
+- **Handling**: Returned immediately with descriptive error message
+- **User Message**: Specific validation error
+
+#### 3. File System Errors (`internal/cmd`)
+- **Type**: Standard Go errors (`os.PathError`, `os.ErrNotExist`)
+- **Handling**: Wrapped with context about operation
+- **User Message**: File path and operation context
+
+#### 4. Validation Errors (`internal/cmd`)
+- **Type**: Custom error messages
+- **Handling**: Returned before API calls
+- **User Message**: Clear guidance on what's wrong and how to fix
+
+### Error Handling Patterns
+
+#### Pattern 1: Early Validation
+```go
+// Validate before processing
+if apiKey == "" {
+    return fmt.Errorf("API key not set. Set it with 'updoc config set api-key <your-key>'")
+}
+```
+
+#### Pattern 2: Error Wrapping
+```go
+// Wrap errors with context
+if err != nil {
+    return fmt.Errorf("parse failed: %w", err)
+}
+```
+
+#### Pattern 3: User-Friendly Messages
+```go
+// Convert technical errors to user-friendly messages
+if apiErr, ok := err.(*api.APIError); ok {
+    return fmt.Errorf("API error: %s", apiErr.Message)
+}
+```
+
+### Error Flow
+
+```mermaid
+graph TB
+    Error[Error Occurs] --> Type{Error Type?}
+    Type -->|API Error| APIErr[APIError]
+    Type -->|Config Error| ConfigErr[ConfigError]
+    Type -->|File Error| FileErr[FileError]
+    Type -->|Validation Error| ValErr[ValidationError]
+    
+    APIErr --> Wrap[Wrap with Context]
+    ConfigErr --> Wrap
+    FileErr --> Wrap
+    ValErr --> Wrap
+    
+    Wrap --> UserMsg[Generate User Message]
+    UserMsg --> CLI[CLI Error Handler]
+    CLI --> Stderr[Write to stderr]
+    Stderr --> Exit[Exit with Code 1]
+```
+
+## Extension Points
+
+### Adding New Output Formats
+
+To add a new output format:
+
+1. **Implement the `Formatter` interface** in `internal/output/formatter.go`:
+```go
+type CustomFormatter struct{}
+
+func (f *CustomFormatter) Format(resp *api.ParseResponse) (string, error) {
+    // Convert resp to custom format
+    return formattedString, nil
+}
+```
+
+2. **Register in `NewFormatter` function**:
+```go
+func NewFormatter(format string) (Formatter, error) {
+    switch format {
+    // ... existing cases
+    case "custom":
+        return &CustomFormatter{}, nil
+    }
+}
+```
+
+3. **Add format validation** in `internal/config/config.go`:
+```go
+ValidFormats = []string{"html", "markdown", "text", "custom"}
+```
+
+4. **Update CLI help text** in `internal/cmd/parse.go`:
+```go
+parseCmd.Flags().StringP("format", "f", "", "output format: html, markdown, text, custom")
+```
+
+### Adding New Commands
+
+To add a new command:
+
+1. **Create command file** in `internal/cmd/`:
+```go
+package cmd
+
+import "github.com/spf13/cobra"
+
+var newCmd = &cobra.Command{
+    Use:   "new <args>",
+    Short: "Command description",
+    Long:  "Detailed description",
+    RunE:  runNew,
+}
+
+func init() {
+    newCmd.Flags().StringP("flag", "f", "", "flag description")
+    rootCmd.AddCommand(newCmd)
+}
+
+func runNew(cmd *cobra.Command, args []string) error {
+    // Command implementation
+    return nil
+}
+```
+
+2. **Register command** in `init()` function of the new file
+
+3. **Update documentation**:
+   - Add to `docs/CLI_MANUAL.md`
+   - Update `README.md` command summary
+
+### Adding New Configuration Options
+
+To add a new configuration option:
+
+1. **Add field to `Config` struct** in `internal/config/config.go`:
+```go
+type Config struct {
+    // ... existing fields
+    NewOption string `yaml:"new_option"`
+}
+```
+
+2. **Add default value**:
+```go
+const DefaultNewOption = "default_value"
+```
+
+3. **Update `Set` and `Get` methods**:
+```go
+func (c *Config) Set(key, value string) error {
+    switch key {
+    // ... existing cases
+    case "new-option":
+        c.NewOption = value
+    }
+}
+
+func (c *Config) Get(key string) (string, error) {
+    switch key {
+    // ... existing cases
+    case "new-option":
+        return c.NewOption, nil
+    }
+}
+```
+
+4. **Update `New` and `Reset` methods** to include the new field
+
+5. **Add CLI flag** if needed in `internal/cmd/root.go` or command-specific files
+
+6. **Update documentation** in `docs/CLI_MANUAL.md`
+
+### Extending API Client
+
+To add new API endpoints:
+
+1. **Add request/response types** in `internal/api/types.go`:
+```go
+type NewRequest struct {
+    // Request fields
+}
+
+type NewResponse struct {
+    // Response fields
+}
+```
+
+2. **Add client method** in `internal/api/client.go`:
+```go
+func (c *Client) NewOperation(ctx context.Context, req *NewRequest) (*NewResponse, error) {
+    // Build request
+    // Send HTTP request
+    // Parse response
+    // Return result
+}
+```
+
+3. **Use in commands** as needed
+
+## Design Decisions
+
+### Why Cobra for CLI?
+- Industry standard for Go CLI applications
+- Excellent flag parsing and validation
+- Built-in help generation
+- Easy command composition
+
+### Why Separate API Client Package?
+- Separation of concerns
+- Easier testing (can mock API client)
+- Reusability if API client is needed elsewhere
+- Clear API boundary
+
+### Why Configuration Hierarchy?
+- Flexibility: users can override defaults at different levels
+- Security: sensitive values (API keys) can come from environment variables
+- Convenience: common settings can be saved in config file
+- Predictability: clear precedence rules
+
+### Why Formatter Interface?
+- Easy to add new output formats
+- Testable (can test formatters independently)
+- Follows Open/Closed Principle
+- Clear separation between API response and output format
+
+## Testing Strategy
+
+### Unit Tests
+- Each package has corresponding `*_test.go` files
+- Test individual components in isolation
+- Mock external dependencies (HTTP client, file system)
+
+### Integration Tests
+- Test component interactions
+- Use test fixtures from `test/testdata/`
+
+### End-to-End Tests
+- Located in `test/e2e/`
+- Require valid API key
+- Test full workflow from CLI to API
+
+## Future Considerations
+
+- **Plugin System**: Allow external formatters via plugins
+- **Streaming Output**: Support streaming for large documents
+- **Retry Logic**: Automatic retry for transient API errors
+- **Rate Limiting**: Client-side rate limiting for API calls
+- **Caching**: Cache API responses for repeated requests
+- **Progress Indicators**: Better progress reporting for batch operations


### PR DESCRIPTION
Completed tasks to fix issue #31 

Created docs/ARCHITECTURE.md (English) with:
System overview with Mermaid diagrams
Package structure documentation
Data flow diagrams (synchronous, asynchronous, batch processing) Configuration hierarchy with resolution flow
Error handling strategy and patterns
Extension points for adding new formats, commands, and configuration Design decisions and testing strategy

Created docs/ARCHITECTURE.ko.md (Korean translation) Complete translation maintaining code examples and diagrams Created docs/ARCHITECTURE.ja.md (Japanese translation) Complete translation maintaining code examples and diagrams 

Updated README.md:
Added architecture documentation link in References section Added note about architecture documentation in Project Structure section Updated CONTRIBUTING.md:

Added architecture documentation to Documentation Files table Added reference to architecture documentation in Project Structure section All documentation uses Mermaid diagrams (black and white) and includes the required sections. The documentation is linked from both README and CONTRIBUTING files, making it easy for new contributors to find and understand the codebase architecture.


